### PR TITLE
change estado.capital_id to nullable

### DIFF
--- a/db/migrate/20170604195827_create_estados.rb
+++ b/db/migrate/20170604195827_create_estados.rb
@@ -3,8 +3,7 @@ class CreateEstados < ActiveRecord::Migration[5.0]
     create_table :estados do |t|
       t.string :sigla
       t.string :nome, null: false
-      t.integer :capital_id, null: false
-
+      t.integer :capital_id
       t.timestamps
     end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -25,11 +25,10 @@ ActiveRecord::Schema.define(version: 20170604200200) do
 
   create_table "estados", force: :cascade do |t|
     t.string   "sigla"
-    t.string   "nome"
+    t.string   "nome",       null: false
     t.integer  "capital_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["capital_id"], name: "index_estados_on_capital_id", using: :btree
   end
 
 end


### PR DESCRIPTION
Ocorre erro ao rodar a `migration ` `PopulaEstadosCidadesDoBrasil` , porque o campo `capital_id` não permite criar o estado sem uma cidade, porém a cidade possui uma relação que não permite cria-la sem o estado. Removendo a restrição de `null` da coluna `estado.capital_id` o problema é corrigido.